### PR TITLE
✨ [FEAT]: WarnOnly Option

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,13 @@ Check out other language support [Python](https://github.com/Onboardbase/secure-
 
 # Contents
 
-- [Install](#install)
-- [Usage](#usage)
+- [Secure log ](#secure-log-)
+- [Contents](#contents)
+  - [Install](#install)
+  - [Usage](#usage)
+    - [Supported console methods](#supported-console-methods)
 - [Roadmap](#roadmap)
+    - [Features](#features)
 
 ## Install
 
@@ -41,15 +45,18 @@ The SecureLog Library also accepts an object.
 export default interface IOptions {
   disableOn?: 'development' | 'production'; // You can use this to specify if you want the SecureLog library to be disabled in a specific environment
   disableConsoleOn?: 'development' | 'production'; // You can use this to disable the console entirely in a specific environment
+  warnOnly?: boolean; // If this is true, secure log will only print out a warning message rather than exit the program when it detects a secret leak. 
 }
 ```
 
 Example:
 
 ```js
-new SecureLog({ disableConsoleOn: 'development' }); // This will disable the SecureLog library on development environment.
+new SecureLog({ disableConsoleOn: 'development', warnOnly: true }); // This will disable the SecureLog library on development environment.
 console.log('sensitive secret here'); // This won't be executed.
 ```
+
+If a secret is detected in a log message, SecureLog can either issue a warning or **exit** the process, depending on the `warnOnly` option. The default value for `warnOnly` is `false`, hence SecureLog will exit the process when it detects a secret leak.
 
 The `disableConsoleOn` option passed to the `SecureLog` library will ensure that the `console.log` statement is not executed.
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.2",
+  "version": "2.0.0",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,7 @@ const checkForStringOccurences = (data: {
 
       if (hasMatch) {
         cachedConsole.warn(
-          `${secretValue} is present in "${value}" and is a valid secret value for the key: "${secretKey}"`
+          `the value of the secret: "${secretKey}", is being leaked!`
         );
 
         if (!options?.warnOnly) {

--- a/src/interfaces/options.interface.ts
+++ b/src/interfaces/options.interface.ts
@@ -1,4 +1,21 @@
+/**
+ * Represents the options for the secure-log library.
+ */
 export default interface IOptions {
+  /**
+   * Specifies when to disable the secure-log functionality.
+   * It can be set to 'development' or 'production'.
+   */
   disableOn?: 'development' | 'production';
+
+  /**
+   * Specifies when to disable logging to the console.
+   * It can be set to 'development' or 'production'.
+   */
   disableConsoleOn?: 'development' | 'production';
+
+  /**
+   * Specifies whether to only log warnings instead of throwing errors.
+   */
+  warnOnly?: boolean;
 }


### PR DESCRIPTION
- Introduced `warnOnly` option, that can be used to control if secure log should only print a warning or throw an error when a secret leak is detected
- Also stopped printing the secret value in the warning message 