### PR TITLE
fix: logging nested objects

### DIFF
--- a/src/utils/stringOccurInObjectValue.ts
+++ b/src/utils/stringOccurInObjectValue.ts
@@ -3,13 +3,13 @@ import IOptions from '../interfaces/options.interface';
 export const stringOccurInObjectValues = (data: {
   needle: string;
   obj: Record<string, any>;
-}) => {
+}): string | null => {
   const { needle, obj } = data;
   if (needle) {
     return Object.keys(obj).find(secretKey => {
       const secretValue = (obj || {})[secretKey];
       return secretValue.length > 1 && needle.includes(secretValue);
-    });
+    }) ?? null;
   }
   return null;
 };

--- a/test/log.test.ts
+++ b/test/log.test.ts
@@ -81,4 +81,32 @@ describe('Test console.log', () => {
       'the value of the secret: "PORT", is being leaked!'
     );
   });
+
+  it('should mask secrets when they are part of an object', () => {
+    secureLog.log('running on port', {secretPort: secrets.PORT});
+    expect(mockObj.warn).toHaveBeenCalledWith(
+      'the value of the secret: "PORT", is being leaked!'
+    );
+  });
+
+  it('should mask secrets when they are part of an array', () => {
+    secureLog.log('running on port', [secrets.PORT]);
+    expect(mockObj.warn).toHaveBeenCalledWith(
+      'the value of the secret: "PORT", is being leaked!'
+    );
+  });
+
+  it('should mask secrets when they are part of a nested object', () => {
+    secureLog.log('running on port', {innerValue: {secretPort: secrets.PORT}});
+    expect(mockObj.warn).toHaveBeenCalledWith(
+      'the value of the secret: "PORT", is being leaked!'
+    );
+  });
+
+  it('should mask secrets when they are part of a nested array', () => {
+    secureLog.log('running on port', {innerValue: [secrets.PORT]});
+    expect(mockObj.warn).toHaveBeenCalledWith(
+      'the value of the secret: "PORT", is being leaked!'
+    );
+  });
 });


### PR DESCRIPTION
Nested objects in log contexts currently result in a crash. This PR proposes a refactor for `checkForPotentialSecrets` which improves its internal typing as well as fixes this issue. 

Test cases demonstrating the problem are included.